### PR TITLE
Add Results button for a team

### DIFF
--- a/teamInfo.py
+++ b/teamInfo.py
@@ -17,6 +17,7 @@ class BaseTeamView(View):
         self.players_data = team_data["data"].get("players", [])
         self.staff_data = team_data["data"].get("staff", [])
         self.upcoming_matches = team_data["data"].get("upcoming", [])
+        self.results = team_data["data"].get("results", [])
 
         vlr_url = f"https://www.vlr.gg/team/{team_id}"
         self.add_item(Button(
@@ -87,9 +88,47 @@ class BaseTeamView(View):
 
             if self.team_logo:
                 embed.set_thumbnail(url=self.team_logo)
+            embed.set_footer(text=f"Team ID: {self.team_id}")
 
         else:
             embed.description = "No upcoming matches"
+            if self.team_logo:
+                embed.set_thumbnail(url=self.team_logo)
+        return embed
+    
+    def create_results_embed(self):
+        embed = Embed(title=f"{self.team_name} - Recent Results", color=discord.Color.brand_green())
+
+        if self.results and len(self.results) > 0:
+            list_of_matches = []
+
+            for i, match in enumerate(self.results[:15]):
+
+                event_name = (match["event"]["name"] or "N/A")[:22].ljust(22)
+
+                team1 = match["teams"][0]
+                team2 = match["teams"][1]
+
+                tag1 = (team1.get("tag") or "N/A")[:5].ljust(5)
+                tag2 = (team2.get("tag") or "N/A")[:5].ljust(5)
+                score = f"{team1.get('points') or 0}-{team2.get('points') or 0}".center(5)
+
+                match_text = f"{score} · {tag1.strip()} vs {tag2.strip()}"
+                match_line = f"{match_text.ljust(20)}| {event_name}"
+
+                list_of_matches.append(match_line)
+
+            matches_text = "\n".join(list_of_matches)
+            matches_text = f"```{matches_text}```\nView full results on the team's VLR page"
+
+            embed.description = matches_text
+
+            if self.team_logo:
+                embed.set_thumbnail(url=self.team_logo)
+
+            embed.set_footer(text=f"Team ID: {self.team_id}")
+        else:
+            embed.description = "No recent results"
             if self.team_logo:
                 embed.set_thumbnail(url=self.team_logo)
         return embed
@@ -106,6 +145,12 @@ class TeamInfoView(BaseTeamView):
         matches_view = UpcomingMatchesView(self.team_data, self.team_id)
         matches_embed = self.create_upcoming_embed()
         await interaction.response.edit_message(embed=matches_embed, view=matches_view)
+    
+    @discord.ui.button(label="View Results 📊", style=ButtonStyle.green, custom_id="view_results_from_matches")
+    async def view_results_button(self, interaction: Interaction, button: Button):
+        results_view = ResultsView(self.team_data, self.team_id)
+        results_embed = self.create_results_embed()
+        await interaction.response.edit_message(embed=results_embed, view=results_view)
 
 class StaffView(BaseTeamView):
     @discord.ui.button(label="View Players 👥", style=ButtonStyle.primary, custom_id="view_players")
@@ -119,6 +164,12 @@ class StaffView(BaseTeamView):
         matches_view = UpcomingMatchesView(self.team_data, self.team_id)
         matches_embed = self.create_upcoming_embed()
         await interaction.response.edit_message(embed=matches_embed, view=matches_view)
+    
+    @discord.ui.button(label="View Results 📊", style=ButtonStyle.green, custom_id="view_results_from_matches")
+    async def view_results_button(self, interaction: Interaction, button: Button):
+        results_view = ResultsView(self.team_data, self.team_id)
+        results_embed = self.create_results_embed()
+        await interaction.response.edit_message(embed=results_embed, view=results_view)
 
 class UpcomingMatchesView(BaseTeamView):
     @discord.ui.button(label="View Players 👥", style=ButtonStyle.primary, custom_id="view_players_from_matches")
@@ -133,6 +184,32 @@ class UpcomingMatchesView(BaseTeamView):
         staff_view = StaffView(self.team_data, self.team_id)
         staff_embed = self.create_staff_embed()
         await interaction.response.edit_message(embed=staff_embed, view=staff_view)
+    
+    @discord.ui.button(label="View Results 📊", style=ButtonStyle.green, custom_id="view_results_from_matches")
+    async def view_results_button(self, interaction: Interaction, button: Button):
+        results_view = ResultsView(self.team_data, self.team_id)
+        results_embed = self.create_results_embed()
+        await interaction.response.edit_message(embed=results_embed, view=results_view)
+
+class ResultsView(BaseTeamView):
+    @discord.ui.button(label="View Players 👥", style=ButtonStyle.primary, custom_id="view_players_from_results")
+    async def view_players_button(self, interaction: Interaction, button: Button):
+        player_view = TeamInfoView(self.team_data, self.team_id)
+        player_embed = self.create_player_embed()
+        await interaction.response.edit_message(embed=player_embed, view=player_view)
+    
+    # Add button to view staff
+    @discord.ui.button(label="View Staff 👔", style=ButtonStyle.primary, custom_id="view_staff_from_results")
+    async def view_staff_button(self, interaction: Interaction, button: Button):
+        staff_view = StaffView(self.team_data, self.team_id)
+        staff_embed = self.create_staff_embed()
+        await interaction.response.edit_message(embed=staff_embed, view=staff_view)
+
+    @discord.ui.button(label="View Matches 📅", style=ButtonStyle.success, custom_id="view_matches_from_staff")
+    async def view_matches_button(self, interaction: Interaction, button: Button):
+        matches_view = UpcomingMatchesView(self.team_data, self.team_id)
+        matches_embed = self.create_upcoming_embed()
+        await interaction.response.edit_message(embed=matches_embed, view=matches_view)
 
 async def teamInfoById(interaction: Interaction, team_id: int):
     url = f"http://localhost:5000/api/v1/teams/{team_id}"

--- a/teamInfo.py
+++ b/teamInfo.py
@@ -102,7 +102,7 @@ class BaseTeamView(View):
         if self.results and len(self.results) > 0:
             list_of_matches = []
 
-            for i, match in enumerate(self.results[:15]):
+            for _, match in enumerate(self.results[:15]):
 
                 event_name = (match["event"]["name"] or "N/A")[:22].ljust(22)
 
@@ -134,7 +134,7 @@ class BaseTeamView(View):
         return embed
 
 class TeamInfoView(BaseTeamView):
-    @discord.ui.button(label="View Staff 👔", style=ButtonStyle.primary, custom_id="view_staff")
+    @discord.ui.button(label="View Staff 👔", style=ButtonStyle.primary, custom_id="view_staff_from_players")
     async def view_staff_button(self, interaction: Interaction, button: Button):
         staff_view = StaffView(self.team_data, self.team_id)
         staff_embed = self.create_staff_embed()
@@ -153,7 +153,7 @@ class TeamInfoView(BaseTeamView):
         await interaction.response.edit_message(embed=results_embed, view=results_view)
 
 class StaffView(BaseTeamView):
-    @discord.ui.button(label="View Players 👥", style=ButtonStyle.primary, custom_id="view_players")
+    @discord.ui.button(label="View Players 👥", style=ButtonStyle.primary, custom_id="view_players_from_staff")
     async def view_players_button(self, interaction: Interaction, button: Button):
         player_view = TeamInfoView(self.team_data, self.team_id)
         player_embed = self.create_player_embed()
@@ -165,27 +165,27 @@ class StaffView(BaseTeamView):
         matches_embed = self.create_upcoming_embed()
         await interaction.response.edit_message(embed=matches_embed, view=matches_view)
     
-    @discord.ui.button(label="View Results 📊", style=ButtonStyle.green, custom_id="view_results_from_matches")
+    @discord.ui.button(label="View Results 📊", style=ButtonStyle.green, custom_id="view_results_from_staff")
     async def view_results_button(self, interaction: Interaction, button: Button):
         results_view = ResultsView(self.team_data, self.team_id)
         results_embed = self.create_results_embed()
         await interaction.response.edit_message(embed=results_embed, view=results_view)
 
 class UpcomingMatchesView(BaseTeamView):
-    @discord.ui.button(label="View Players 👥", style=ButtonStyle.primary, custom_id="view_players_from_matches")
+    @discord.ui.button(label="View Players 👥", style=ButtonStyle.primary, custom_id="view_players_from_upcoming")
     async def view_players_button(self, interaction: Interaction, button: Button):
         player_view = TeamInfoView(self.team_data, self.team_id)
         player_embed = self.create_player_embed()
         await interaction.response.edit_message(embed=player_embed, view=player_view)
     
     # Add button to view staff
-    @discord.ui.button(label="View Staff 👔", style=ButtonStyle.primary, custom_id="view_staff_from_matches")
+    @discord.ui.button(label="View Staff 👔", style=ButtonStyle.primary, custom_id="view_staff_from_upcoming")
     async def view_staff_button(self, interaction: Interaction, button: Button):
         staff_view = StaffView(self.team_data, self.team_id)
         staff_embed = self.create_staff_embed()
         await interaction.response.edit_message(embed=staff_embed, view=staff_view)
     
-    @discord.ui.button(label="View Results 📊", style=ButtonStyle.green, custom_id="view_results_from_matches")
+    @discord.ui.button(label="View Results 📊", style=ButtonStyle.green, custom_id="view_results_from_upcoming")
     async def view_results_button(self, interaction: Interaction, button: Button):
         results_view = ResultsView(self.team_data, self.team_id)
         results_embed = self.create_results_embed()
@@ -205,7 +205,7 @@ class ResultsView(BaseTeamView):
         staff_embed = self.create_staff_embed()
         await interaction.response.edit_message(embed=staff_embed, view=staff_view)
 
-    @discord.ui.button(label="View Matches 📅", style=ButtonStyle.success, custom_id="view_matches_from_staff")
+    @discord.ui.button(label="View Matches 📅", style=ButtonStyle.success, custom_id="view_matches_from_results")
     async def view_matches_button(self, interaction: Interaction, button: Button):
         matches_view = UpcomingMatchesView(self.team_data, self.team_id)
         matches_embed = self.create_upcoming_embed()


### PR DESCRIPTION
This pull request includes several changes to the `teamInfo.py` file, primarily focused on adding functionality to display recent results for a team and enhancing the user interface with new buttons. The most important changes are detailed below:

Enhancements to data handling:

* Added a new attribute `self.results` to store recent match results in the `__init__` method.

User interface improvements:

* Added a footer displaying the team ID in the `create_upcoming_embed` method.
* Introduced a new method `create_results_embed` to generate an embed for recent match results, including logic to format and display results.

New button functionalities:

* Added a new button labeled "View Results 📊" in multiple views (`TeamInfoView`, `UpcomingMatchesView`, `StaffView`) to allow users to view recent match results. [[1]](diffhunk://#diff-b8179312c73b5b2f1c8648af6b98fe3e95ddb86384b58da249c852ce951c0f36R149-R154) [[2]](diffhunk://#diff-b8179312c73b5b2f1c8648af6b98fe3e95ddb86384b58da249c852ce951c0f36R168-R173) [[3]](diffhunk://#diff-b8179312c73b5b2f1c8648af6b98fe3e95ddb86384b58da249c852ce951c0f36R188-R213)
* Created a new `ResultsView` class with buttons to navigate between different team information views (players, staff, matches).

Result:
![image](https://github.com/user-attachments/assets/345118d2-685b-45ef-bff8-5eb96eb2f055)
