### PR TITLE
Update caches to pull ALL players/teams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 .env
 team_cache.json
+player_cache.json


### PR DESCRIPTION
This PR is in relation to #28 and #29, where not all the players and teams were being put in. 

The new approach should in theory grab every team in every region and every player in every region during the entire lifespan of the VCT and save them to JSON caches to be used